### PR TITLE
feat(metrics): add energy and kitten job metrics

### DIFF
--- a/source/KittenAnalysts.ts
+++ b/source/KittenAnalysts.ts
@@ -22,6 +22,8 @@ export type KittenAnalystsMessageId =
 	| "connected"
 	| "getBuildings"
 	| "getCalendar"
+	| "getEnergy"
+	| "getJobs"
 	| "getPollution"
 	| "getRaces"
 	| "getResourcePool"
@@ -51,6 +53,18 @@ export type PayloadCalendar = Array<{
 	seasonsPerYear: number;
 	year: number;
 	yearsPerCycle: number;
+}>;
+export type PayloadEnergy = Array<{
+	consumption: number;
+	label: string;
+	name: string;
+	production: number;
+}>;
+export type PayloadJobs = Array<{
+	label: string;
+	name: string;
+	unlocked: boolean;
+	value: number;
 }>;
 export type PayloadPollution = Array<{
 	label: string;
@@ -91,25 +105,29 @@ export interface KittenAnalystsMessage<
 	TMessage extends KittenAnalystsMessageId,
 	TData = TMessage extends "getBuildings"
 		? PayloadBuildings
-		: TMessage extends "getCalendar"
-			? PayloadCalendar
-			: TMessage extends "getPollution"
-				? PayloadPollution
-				: TMessage extends "getRaces"
-					? PayloadRaces
-					: TMessage extends "getResourcePool"
-						? PayloadResources
-						: TMessage extends "getStatistics"
-							? PayloadStatistics
-							: TMessage extends "getTechnologies"
-								? PayloadTechnologies
-								: TMessage extends "reportFrame"
-									? unknown
-									: TMessage extends "reportSavegame"
-										? unknown
-										: TMessage extends "injectSavegame"
-											? KGNetSavePersisted
-											: never,
+		: TMessage extends "getEnergy"
+			? PayloadEnergy
+			: TMessage extends "getJobs"
+				? PayloadJobs
+				: TMessage extends "getCalendar"
+					? PayloadCalendar
+					: TMessage extends "getPollution"
+						? PayloadPollution
+						: TMessage extends "getRaces"
+							? PayloadRaces
+							: TMessage extends "getResourcePool"
+								? PayloadResources
+								: TMessage extends "getStatistics"
+									? PayloadStatistics
+									: TMessage extends "getTechnologies"
+										? PayloadTechnologies
+										: TMessage extends "reportFrame"
+											? unknown
+											: TMessage extends "reportSavegame"
+												? unknown
+												: TMessage extends "injectSavegame"
+													? KGNetSavePersisted
+													: never,
 > {
 	/**
 	 * The payload of the message.
@@ -438,6 +456,60 @@ export class KittenAnalysts {
 					location: this.location,
 					responseId: message.responseId,
 
+					type: message.type,
+				};
+			}
+
+			case "getEnergy": {
+				const energyBuildings = game.bld.meta[0].meta.filter(
+					(_) =>
+						!isNil(_.effects?.energyProduction) ||
+						!isNil(_.effects?.energyConsumption),
+				);
+
+				const data: PayloadEnergy = [
+					{
+						consumption: game.resPool.energyCons,
+						label: "Total",
+						name: "energy",
+						production: game.resPool.energyProd,
+					},
+					...energyBuildings.map((_) => ({
+						consumption: (_.effects?.energyConsumption ?? 0) * _.on,
+						label: _.label ?? "",
+						name: _.name,
+						production: (_.effects?.energyProduction ?? 0) * _.on,
+					})),
+				];
+
+				return {
+					client_type: this.location.includes("headless.html")
+						? "headless"
+						: "browser",
+					data,
+					guid: game.telemetry.guid,
+					location: this.location,
+					responseId: message.responseId,
+					type: message.type,
+				};
+			}
+
+			case "getJobs": {
+				const data: PayloadJobs = game.village.jobs.map((job) => ({
+					label: job.title,
+					name: job.name,
+					unlocked: job.unlocked,
+					value: job.value,
+				}));
+
+				return {
+					client_type: this.location.includes("headless.html")
+						? "headless"
+						: "browser",
+					data,
+					guid: game.telemetry.guid,
+					location: this.location,
+					responseId: message.responseId,
 					type: message.type,
 				};
 			}

--- a/source/entrypoint-backend.ts
+++ b/source/entrypoint-backend.ts
@@ -21,6 +21,8 @@ import type {
 	KittenAnalystsMessageId,
 	PayloadBuildings,
 	PayloadCalendar,
+	PayloadEnergy,
+	PayloadJobs,
 	PayloadPollution,
 	PayloadRaces,
 	PayloadResources,
@@ -35,10 +37,13 @@ import { kg_clicks_total } from "./metrics/kg_clicks_total.js";
 import { kg_crafts_total } from "./metrics/kg_crafts_total.js";
 import { kg_crypto_price } from "./metrics/kg_crypto_price.js";
 import { kg_embassy_level } from "./metrics/kg_embassy_level.js";
+import { kg_energy_consumption } from "./metrics/kg_energy_consumption.js";
+import { kg_energy_production } from "./metrics/kg_energy_production.js";
 import { kg_events_observed } from "./metrics/kg_events_observed.js";
 import { kg_festival_days } from "./metrics/kg_festival_days.js";
 import { kg_kittens_average } from "./metrics/kg_kittens_average.js";
 import { kg_kittens_dead } from "./metrics/kg_kittens_dead.js";
+import { kg_kittens_job } from "./metrics/kg_kittens_job.js";
 import { kg_kittens_total } from "./metrics/kg_kittens_total.js";
 import { kg_paragon_total } from "./metrics/kg_paragon_total.js";
 import { kg_pollution_production } from "./metrics/kg_pollution_prodution.js";
@@ -105,6 +110,8 @@ const cache = new Map<
 			KittenAnalystsMessageId,
 			| PayloadBuildings
 			| PayloadCalendar
+			| PayloadEnergy
+			| PayloadJobs
 			| PayloadPollution
 			| PayloadRaces
 			| PayloadResources
@@ -131,6 +138,11 @@ register.registerMetric(kg_resource_rate(cache, remote));
 register.registerMetric(kg_embassy_level(cache, remote));
 register.registerMetric(kg_race_energy(cache, remote));
 register.registerMetric(kg_race_standing(cache, remote));
+
+register.registerMetric(kg_energy_production(cache, remote));
+register.registerMetric(kg_energy_consumption(cache, remote));
+
+register.registerMetric(kg_kittens_job(cache, remote));
 
 register.registerMetric(kg_crypto_price(cache, remote));
 register.registerMetric(kg_festival_days(cache, remote));

--- a/source/metrics/factory.ts
+++ b/source/metrics/factory.ts
@@ -4,6 +4,8 @@ import type { MessageCache } from "../entrypoint-backend.js";
 import type {
 	PayloadBuildings,
 	PayloadCalendar,
+	PayloadEnergy,
+	PayloadJobs,
 	PayloadPollution,
 	PayloadRaces,
 	PayloadResources,
@@ -16,6 +18,8 @@ export const gaugeFactory = <
 	TMessage extends
 		| "getBuildings"
 		| "getCalendar"
+		| "getEnergy"
+		| "getJobs"
 		| "getPollution"
 		| "getRaces"
 		| "getResourcePool"
@@ -25,25 +29,31 @@ export const gaugeFactory = <
 	TData extends
 		| PayloadBuildings
 		| PayloadCalendar
+		| PayloadEnergy
+		| PayloadJobs
 		| PayloadPollution
 		| PayloadRaces
 		| PayloadResources
 		| PayloadStatistics
 		| PayloadTechnologies = TMessage extends "getBuildings"
 		? PayloadBuildings
-		: TMessage extends "getCalendar"
-			? PayloadCalendar
-			: TMessage extends "getPollution"
-				? PayloadPollution
-				: TMessage extends "getRaces"
-					? PayloadRaces
-					: TMessage extends "getResourcePool"
-						? PayloadResources
-						: TMessage extends "getStatistics"
-							? PayloadStatistics
-							: TMessage extends "getTechnologies"
-								? PayloadTechnologies
-								: never,
+		: TMessage extends "getEnergy"
+			? PayloadEnergy
+			: TMessage extends "getJobs"
+				? PayloadJobs
+				: TMessage extends "getCalendar"
+					? PayloadCalendar
+					: TMessage extends "getPollution"
+						? PayloadPollution
+						: TMessage extends "getRaces"
+							? PayloadRaces
+							: TMessage extends "getResourcePool"
+								? PayloadResources
+								: TMessage extends "getStatistics"
+									? PayloadStatistics
+									: TMessage extends "getTechnologies"
+										? PayloadTechnologies
+										: never,
 >(instructions: {
 	cache: MessageCache;
 	remote: KittensGameRemote;

--- a/source/metrics/kg_energy_consumption.ts
+++ b/source/metrics/kg_energy_consumption.ts
@@ -1,0 +1,35 @@
+import { ucfirst } from "@kitten-science/kitten-scientists/tools/Format.js";
+import type { MessageCache } from "../entrypoint-backend.js";
+import type { KittensGameRemote } from "../network/KittensGameRemote.js";
+import { gaugeFactory } from "./factory.js";
+
+export const kg_energy_consumption = (
+	cache: MessageCache,
+	remote: KittensGameRemote,
+) =>
+	gaugeFactory({
+		cache,
+		extract(client_type, guid, location, element, subject) {
+			// The grand total (name "energy") is always reported; individual
+			// buildings are only reported when they actually consume energy.
+			if (element.name !== "energy" && element.consumption === 0) {
+				return;
+			}
+
+			subject.set(
+				{
+					client_type,
+					guid,
+					label: ucfirst(element.label),
+					location,
+					name: element.name,
+				},
+				element.consumption,
+			);
+		},
+		help: "How much energy is consumed, in total (name 'energy') and per building.",
+		labelNames: ["client_type", "guid", "label", "location", "name"] as const,
+		name: "kg_energy_consumption",
+		remote,
+		require: "getEnergy",
+	});

--- a/source/metrics/kg_energy_production.ts
+++ b/source/metrics/kg_energy_production.ts
@@ -1,0 +1,35 @@
+import { ucfirst } from "@kitten-science/kitten-scientists/tools/Format.js";
+import type { MessageCache } from "../entrypoint-backend.js";
+import type { KittensGameRemote } from "../network/KittensGameRemote.js";
+import { gaugeFactory } from "./factory.js";
+
+export const kg_energy_production = (
+	cache: MessageCache,
+	remote: KittensGameRemote,
+) =>
+	gaugeFactory({
+		cache,
+		extract(client_type, guid, location, element, subject) {
+			// The grand total (name "energy") is always reported; individual
+			// buildings are only reported when they actually produce energy.
+			if (element.name !== "energy" && element.production === 0) {
+				return;
+			}
+
+			subject.set(
+				{
+					client_type,
+					guid,
+					label: ucfirst(element.label),
+					location,
+					name: element.name,
+				},
+				element.production,
+			);
+		},
+		help: "How much energy is produced, in total (name 'energy') and per building.",
+		labelNames: ["client_type", "guid", "label", "location", "name"] as const,
+		name: "kg_energy_production",
+		remote,
+		require: "getEnergy",
+	});

--- a/source/metrics/kg_kittens_job.ts
+++ b/source/metrics/kg_kittens_job.ts
@@ -1,0 +1,34 @@
+import { ucfirst } from "@kitten-science/kitten-scientists/tools/Format.js";
+import type { MessageCache } from "../entrypoint-backend.js";
+import type { KittensGameRemote } from "../network/KittensGameRemote.js";
+import { gaugeFactory } from "./factory.js";
+
+export const kg_kittens_job = (
+	cache: MessageCache,
+	remote: KittensGameRemote,
+) =>
+	gaugeFactory({
+		cache,
+		extract(client_type, guid, location, element, subject) {
+			// Only report jobs the player has actually unlocked.
+			if (!element.unlocked) {
+				return;
+			}
+
+			subject.set(
+				{
+					client_type,
+					guid,
+					job: element.name,
+					label: ucfirst(element.label),
+					location,
+				},
+				element.value,
+			);
+		},
+		help: "How many kittens are assigned to each job.",
+		labelNames: ["client_type", "guid", "job", "label", "location"] as const,
+		name: "kg_kittens_job",
+		remote,
+		require: "getJobs",
+	});


### PR DESCRIPTION
Add three Prometheus metrics sourced from getEnergy and getJobs client messages:

- kg_energy_production / kg_energy_consumption: total (name "energy") and per-building electricity, derived from resPool energy totals and each building's energyProduction/energyConsumption effect times its active count.
- kg_kittens_job: population assigned to each unlocked village job.

Wires the two message ids through the KittenAnalystsMessage payload map, the gaugeFactory type union, and the backend metric registrations.